### PR TITLE
6 nodetype system v1 definition loader inheritance

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -2,5 +2,6 @@
   <profile version="1.0">
     <option name="myName" value="Project Default" />
     <inspection_tool class="PhpCSFixerValidationInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+    <inspection_tool class="PhpStanGlobal" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
   </profile>
 </component>

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -5,7 +5,7 @@
   </component>
   <component name="PHPCSFixerOptionsConfiguration">
     <option name="codingStandard" value="Custom" />
-    <option name="rulesetPath" value="$PROJECT_DIR$/.php-cs-fixer.dist.php" />
+    <option name="rulesetPath" value="$PROJECT_DIR$/.php-cs-fixer.php" />
     <option name="transferred" value="true" />
   </component>
   <component name="PHPCodeSnifferOptionsConfiguration">
@@ -22,6 +22,9 @@
     <phpcs_settings>
       <phpcs_by_interpreter asDefaultInterpreter="true" interpreter_id="7ffdb1dd-0fce-4185-8da4-a16a1ba0404d" timeout="30000" />
     </phpcs_settings>
+  </component>
+  <component name="PhpExternalFormatter">
+    <option name="externalFormatter" value="PHP_CS_FIXER" />
   </component>
   <component name="PhpIncludePathManager">
     <include_path>
@@ -153,10 +156,13 @@
   <component name="PhpStan">
     <PhpStan_settings>
       <PhpStanConfiguration tool_path="$PROJECT_DIR$/vendor/bin/phpstan" />
-      <phpstan_by_interpreter asDefaultInterpreter="true" interpreter_id="7ffdb1dd-0fce-4185-8da4-a16a1ba0404d" tool_path="$PROJECT_DIR$/vendor/bin/phpstan" timeout="60000" />
+      <phpstan_by_interpreter asDefaultInterpreter="true" interpreter_id="7ffdb1dd-0fce-4185-8da4-a16a1ba0404d" tool_path="F:\aurora-cms\aurora-core\vendor\bin\phpstan" timeout="60000" />
     </PhpStan_settings>
   </component>
   <component name="PhpStanOptionsConfiguration">
+    <option name="config" value="F:\aurora-cms\aurora-core\phpstan.dist.neon" />
+    <option name="fullProject" value="true" />
+    <option name="level" value="8" />
     <option name="transferred" value="true" />
   </component>
   <component name="PhpUnit">

--- a/.idea/symfony2.xml
+++ b/.idea/symfony2.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="Symfony2PluginSettings">
     <option name="pluginEnabled" value="true" />
+    <option name="profilerCsvPath" value="" />
   </component>
 </project>

--- a/config/node_types/exhaustive-example.yaml
+++ b/config/node_types/exhaustive-example.yaml
@@ -1,0 +1,27 @@
+exhaustive-base:
+  properties:
+    stringValue: { type: string }
+    nullableString: { type: string, nullable: true }
+    intValue: { type: int }
+    floatValue: { type: float }
+    boolValue: { type: bool }
+    datetimeValue: { type: datetime, nullable: true }
+    jsonValue: { type: json, nullable: true }
+    arrayValue: { type: array, nullable: true }
+    referenceId: { type: reference }
+    stringList: { type: string, multiple: true }
+    intList: { type: int, multiple: true }
+    floatList: { type: float, multiple: true }
+    boolList: { type: bool, multiple: true }
+    datetimeList: { type: datetime, multiple: true }
+    jsonList: { type: json, multiple: true }
+    references: { type: reference, multiple: true }
+
+exhaustive-example:
+  extends: exhaustive-base
+  properties:
+    # Override an inherited property to allow nulls
+    stringValue: { type: string, nullable: true }
+    # Add a new extra field
+    extraProperty: { type: json }
+

--- a/infection.json5
+++ b/infection.json5
@@ -11,6 +11,26 @@
         ]
     },
     "mutators": {
-        "@default": true
+        "@default": true,
+        "UnwrapArrayValues": {
+            "ignore": [
+                "Aurora\\Domain\\ContentRepository\\Value\\NodePath::fromString"
+            ]
+        },
+        "UnwrapRtrim": {
+            "ignore": [
+                "Aurora\\Domain\\ContentRepository\\Value\\NodePath::fromString"
+            ]
+        },
+        "Throw_": {
+            "ignore": [
+                "Aurora\\Domain\\ContentRepository\\Value\\NodePath::fromString"
+            ]
+        },
+        "ReturnRemoval": {
+            "ignore": [
+                "Aurora\\Infrastructure\\ContentRepository\\NodeTypes\\NodeTypeResolver::resolve"
+            ]
+        }
     }
 }

--- a/src/Domain/ContentRepository/Workspace.php
+++ b/src/Domain/ContentRepository/Workspace.php
@@ -145,7 +145,7 @@ final class Workspace
      * @param NodeId               $parentId   the identifier of the parent node under which this node will be created
      * @param string               $segment    the unique segment name for the node within its siblings
      *
-     * @throws NodeAlreadyExists if a node with the same segment name already exists within the     siblings, or if a node with the same ID already exists
+     * @throws NodeAlreadyExists if a node with the same segment name already exists within the siblings, or if a node with the same ID already exists
      * @throws \Exception
      */
     public function createNode(NodeId $id, NodeType $type, array $properties, NodeId $parentId, string $segment): void
@@ -221,7 +221,7 @@ final class Workspace
             throw new InvalidMove('Cannot move node into its own subtree');
         }
 
-        // Sibling name conflict at new parent
+        // Sibling name conflict with new parent
         $segment = $node->path->name();
         foreach ($this->childrenOf($newParentId) as $sibling) {
             if ($sibling->path->name() === $segment) {
@@ -229,7 +229,7 @@ final class Workspace
             }
         }
 
-        // Update path for the node and all descendants
+        // Update the path for the node and all descendants
         $oldPath = (string) $node->path;
         $newPath = (string) $newParent->path->append($segment);
 
@@ -250,7 +250,7 @@ final class Workspace
             }
         }
 
-        // rebuild index for new subtree
+        // rebuild index for the new subtree
         foreach ($this->nodes as $k => $n) {
             if (str_starts_with($n->path.'/', $newPath.'/') || (string) $n->path === $newPath) {
                 $this->pathIndex[(string) $n->path] = $k;

--- a/src/Infrastructure/ContentRepository/NodeTypes/DefinitionLoader.php
+++ b/src/Infrastructure/ContentRepository/NodeTypes/DefinitionLoader.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Aurora Core.
+ *
+ * (c) The Aurora Core contributors
+ * License: MIT
+ */
+
+namespace Aurora\Infrastructure\ContentRepository\NodeTypes;
+
+use Aurora\Infrastructure\ContentRepository\NodeTypes\Exception\InvalidNodeTypeDefinition;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Loads raw NodeType definitions from YAML/JSON files.
+ *
+ * Expected file structure (YAML example):
+ *
+ *   article:
+ *     extends: 'document'
+ *     properties:
+ *       title: { type: string, nullable: false }
+ *       tags:  { type: string, multiple: true }
+ */
+final class DefinitionLoader
+{
+    /**
+     * @param list<string>|null $paths Optional explicit search paths. If null/empty, defaults to '<project>/config/node_types'.
+     */
+    public function __construct(private readonly ?array $paths = null)
+    {
+    }
+
+    /**
+     * @return array<string, array{extends: string|null, properties?: array<string, array{type: string, nullable?: bool, multiple?: bool}>}>
+     */
+    public function load(): array
+    {
+        $definitions = [];
+
+        $paths = $this->paths ?? [$this->defaultPath()];
+        foreach ($paths as $dir) {
+            if (!is_dir($dir)) {
+                // silently ignore non-existing directories for flexibility
+                continue;
+            }
+
+            $files = scandir($dir) ?: [];
+            foreach ($files as $file) {
+                if ('.' === $file || '..' === $file) {
+                    continue;
+                }
+                $path = rtrim($dir, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$file;
+                if (!is_file($path)) {
+                    continue;
+                }
+
+                $ext = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+                if (!\in_array($ext, ['yml', 'yaml', 'json'], true)) {
+                    continue;
+                }
+
+                $data = $this->parseFile($path, $ext);
+                if (!\is_array($data)) {
+                    throw new InvalidNodeTypeDefinition(\sprintf('File %s must define an object at the root.', $path));
+                }
+
+                foreach ($data as $name => $def) {
+                    if (!\is_string($name)) {
+                        throw new InvalidNodeTypeDefinition(\sprintf('Invalid node type key in %s. Expected string, got %s.', $path, get_debug_type($name)));
+                    }
+                    if (!\is_array($def)) {
+                        throw new InvalidNodeTypeDefinition(\sprintf('Definition for "%s" in %s must be a map/object.', $name, $path));
+                    }
+
+                    if (isset($definitions[$name])) {
+                        throw new InvalidNodeTypeDefinition(\sprintf('Duplicate node type "%s" found in %s.', $name, $path));
+                    }
+
+                    // Normalize structure
+                    /** @var string|null $extends */
+                    $extends = (isset($def['extends']) && \is_string($def['extends'])) ? $def['extends'] : null;
+                    $properties = [];
+                    if (isset($def['properties'])) {
+                        if (!\is_array($def['properties'])) {
+                            throw new InvalidNodeTypeDefinition(\sprintf('"properties" of "%s" must be a map/object.', $name));
+                        }
+                        foreach ($def['properties'] as $propName => $prop) {
+                            if (!\is_string($propName)) {
+                                throw new InvalidNodeTypeDefinition(\sprintf('Invalid property name for "%s"; expected string.', $name));
+                            }
+                            if (!\is_array($prop)) {
+                                throw new InvalidNodeTypeDefinition(\sprintf('Property "%s.%s" must be a map/object.', $name, $propName));
+                            }
+                            if (!isset($prop['type'])) {
+                                throw new InvalidNodeTypeDefinition(\sprintf('Property "%s.%s" must declare a "type".', $name, $propName));
+                            }
+                            if (!\is_string($prop['type'])) {
+                                throw new InvalidNodeTypeDefinition(\sprintf('Property "%s.%s" type must be a string.', $name, $propName));
+                            }
+                            $properties[$propName] = [
+                                'type' => $prop['type'],
+                                'nullable' => \array_key_exists('nullable', $prop) ? (bool) $prop['nullable'] : false,
+                                'multiple' => \array_key_exists('multiple', $prop) ? (bool) $prop['multiple'] : false,
+                            ];
+                        }
+                    }
+
+                    $definitions[$name] = [
+                        'extends' => $extends,
+                        'properties' => $properties,
+                    ];
+                }
+            }
+        }
+
+        return $definitions;
+    }
+
+    private function parseFile(string $path, string $ext): mixed
+    {
+        try {
+            if ('json' === $ext) {
+                $json = file_get_contents($path);
+                if (false === $json) {
+                    throw new \RuntimeException('Failed to read file.');
+                }
+                $data = json_decode($json, true, flags: JSON_THROW_ON_ERROR);
+
+                return $data;
+            }
+
+            // yaml / yml
+            return Yaml::parseFile($path);
+        } catch (\Throwable $e) {
+            throw new InvalidNodeTypeDefinition(\sprintf('Failed parsing %s: %s', $path, $e->getMessage()), previous: $e);
+        }
+    }
+
+    private function defaultPath(): string
+    {
+        // src/Infrastructure/ContentRepository/NodeTypes -> up 4 = project root
+        $projectDir = \dirname(__DIR__, 4);
+
+        return $projectDir.DIRECTORY_SEPARATOR.'config'.DIRECTORY_SEPARATOR.'node_types';
+    }
+}

--- a/src/Infrastructure/ContentRepository/NodeTypes/Exception/InvalidNodeTypeDefinition.php
+++ b/src/Infrastructure/ContentRepository/NodeTypes/Exception/InvalidNodeTypeDefinition.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Aurora Core.
+ *
+ * (c) The Aurora Core contributors
+ * License: MIT
+ */
+
+namespace Aurora\Infrastructure\ContentRepository\NodeTypes\Exception;
+
+final class InvalidNodeTypeDefinition extends \RuntimeException
+{
+}

--- a/src/Infrastructure/ContentRepository/NodeTypes/NodeTypeResolver.php
+++ b/src/Infrastructure/ContentRepository/NodeTypes/NodeTypeResolver.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Aurora Core.
+ *
+ * (c) The Aurora Core contributors
+ * License: MIT
+ */
+
+namespace Aurora\Infrastructure\ContentRepository\NodeTypes;
+
+use Aurora\Domain\ContentRepository\Type\NodeType;
+use Aurora\Domain\ContentRepository\Type\PropertyDefinition;
+use Aurora\Domain\ContentRepository\Type\PropertyType;
+use Aurora\Infrastructure\ContentRepository\NodeTypes\Exception\InvalidNodeTypeDefinition;
+
+/**
+ * Resolves raw definitions into NodeType domain objects with inheritance & merging.
+ */
+final class NodeTypeResolver
+{
+    /**
+     * @param array<string, array{extends?: string|null, properties?: array<string, array{type: string, nullable?: bool, multiple?: bool}>}> $definitions
+     *
+     * @return array<string, NodeType>
+     */
+    public function resolve(array $definitions): array
+    {
+        $resolving = [];
+        $resolved = [];
+
+        $build = function (string $name) use (&$build, &$resolving, &$resolved, $definitions): NodeType {
+            if (isset($resolved[$name])) {
+                return $resolved[$name];
+            }
+            if (!isset($definitions[$name])) {
+                throw new InvalidNodeTypeDefinition(\sprintf('Unknown parent node type "%s".', $name));
+            }
+            if (isset($resolving[$name])) {
+                throw new InvalidNodeTypeDefinition(\sprintf('Circular inheritance detected for node type "%s".', $name));
+            }
+
+            $resolving[$name] = true;
+            $def = $definitions[$name];
+
+            $inherited = [];
+            if (!empty($def['extends'])) {
+                $parent = $build((string) $def['extends']);
+                // Pull parent definitions
+                $parentProps = $this->extractPropertyDefinitions($parent);
+                foreach ($parentProps as $pd) {
+                    $inherited[$pd->name] = $pd;
+                }
+            }
+
+            // Merge/override with own properties
+            $own = [];
+            $props = $def['properties'] ?? [];
+            foreach ($props as $propName => $p) {
+                $own[$propName] = $this->createPropertyDefinition($propName, $p['type'], $p['nullable'] ?? false, $p['multiple'] ?? false);
+            }
+
+            $final = array_values(array_merge($inherited, $own));
+
+            $resolved[$name] = new NodeType($name, $final);
+            unset($resolving[$name]);
+
+            return $resolved[$name];
+        };
+
+        foreach (array_keys($definitions) as $name) {
+            $build($name);
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @return list<PropertyDefinition>
+     */
+    private function extractPropertyDefinitions(NodeType $type): array
+    {
+        // NodeType doesn't expose all definitions; reflect to fetch private field safely.
+        // This is internal to infrastructure for merging only.
+        $rp = new \ReflectionProperty(NodeType::class, 'definitions');
+        $rp->setAccessible(true);
+        /** @var array<string, PropertyDefinition> $defs */
+        $defs = $rp->getValue($type);
+
+        return array_values($defs);
+    }
+
+    private function createPropertyDefinition(string $name, string $type, bool $nullable, bool $multiple): PropertyDefinition
+    {
+        $enum = PropertyType::tryFrom(strtolower($type));
+        if (!$enum) {
+            throw new InvalidNodeTypeDefinition(\sprintf('Unknown property type "%s" for "%s".', $type, $name));
+        }
+
+        return new PropertyDefinition($name, $enum, $nullable, $multiple);
+    }
+}

--- a/src/Infrastructure/ContentRepository/NodeTypes/NodeTypesCacheWarmer.php
+++ b/src/Infrastructure/ContentRepository/NodeTypes/NodeTypesCacheWarmer.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Aurora Core.
+ *
+ * (c) The Aurora Core contributors
+ * License: MIT
+ */
+
+namespace Aurora\Infrastructure\ContentRepository\NodeTypes;
+
+use Aurora\Domain\ContentRepository\Type\NodeType;
+use Aurora\Domain\ContentRepository\Type\PropertyDefinition;
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+
+/**
+ * Warms cache with resolved node types to avoid re-parsing at runtime.
+ */
+final class NodeTypesCacheWarmer implements CacheWarmerInterface
+{
+    public function __construct(
+        private readonly DefinitionLoader $loader,
+        private readonly NodeTypeResolver $resolver,
+        private readonly ?string $cacheFile = null,
+    ) {
+    }
+
+    public function isOptional(): bool
+    {
+        return false;
+    }
+
+    public function warmUp(string $cacheDir, ?string $buildDir = null): array
+    {
+        $resolved = $this->resolver->resolve($this->loader->load());
+        $payload = [];
+        foreach ($resolved as $type) {
+            $payload[] = $this->exportNodeType($type);
+        }
+
+        $target = $this->cacheFile ?: ($cacheDir.DIRECTORY_SEPARATOR.'aurora_node_types.json');
+        $dir = \dirname($target);
+        if (!is_dir($dir)) {
+            @mkdir($dir, recursive: true);
+        }
+        file_put_contents($target, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+        return [$target];
+    }
+
+    /**
+     * @return array{name: string, properties: list<array{name: string, type: string, nullable: bool, multiple: bool}>}
+     */
+    private function exportNodeType(NodeType $type): array
+    {
+        $rp = new \ReflectionProperty(NodeType::class, 'definitions');
+        $rp->setAccessible(true);
+        /** @var array<string, PropertyDefinition> $defs */
+        $defs = $rp->getValue($type);
+
+        $props = [];
+        foreach ($defs as $pd) {
+            $props[] = [
+                'name' => $pd->name,
+                'type' => $pd->type->value,
+                'nullable' => $pd->nullable,
+                'multiple' => $pd->multiple,
+            ];
+        }
+
+        return [
+            'name' => $type->name,
+            'properties' => $props,
+        ];
+    }
+}

--- a/src/Infrastructure/DependencyInjection/AuroraInfrastructureExtension.php
+++ b/src/Infrastructure/DependencyInjection/AuroraInfrastructureExtension.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Aurora Core.
+ *
+ * (c) The Aurora Core contributors
+ * License: MIT
+ */
+
+namespace Aurora\Infrastructure\DependencyInjection;
+
+use Aurora\Infrastructure\Persistence\ContentRepository\ConfigNodeTypeRepository;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+
+final class AuroraInfrastructureExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+        // Prefer config-backed repository by default
+        $container->setAlias('Aurora\\Application\\ContentRepository\\Port\\NodeTypeRepository', ConfigNodeTypeRepository::class);
+    }
+}

--- a/src/Infrastructure/Persistence/ContentRepository/ConfigNodeTypeRepository.php
+++ b/src/Infrastructure/Persistence/ContentRepository/ConfigNodeTypeRepository.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Aurora Core.
+ *
+ * (c) The Aurora Core contributors
+ * License: MIT
+ */
+
+namespace Aurora\Infrastructure\Persistence\ContentRepository;
+
+use Aurora\Application\ContentRepository\Port\NodeTypeRepository;
+use Aurora\Domain\ContentRepository\Exception\NodeTypeNotFound;
+use Aurora\Domain\ContentRepository\Type\NodeType;
+use Aurora\Domain\ContentRepository\Type\PropertyDefinition;
+use Aurora\Domain\ContentRepository\Type\PropertyType;
+use Aurora\Infrastructure\ContentRepository\NodeTypes\DefinitionLoader;
+use Aurora\Infrastructure\ContentRepository\NodeTypes\NodeTypeResolver;
+
+/**
+ * NodeType repository backed by config files with optional cache file.
+ */
+final class ConfigNodeTypeRepository implements NodeTypeRepository
+{
+    /** @var array<string, NodeType>|null */
+    private ?array $types = null;
+
+    public function __construct(
+        private readonly DefinitionLoader $loader,
+        private readonly NodeTypeResolver $resolver,
+        private readonly ?string $cacheFile = null,
+    ) {
+    }
+
+    public function register(NodeType $type): void
+    {
+        $this->ensureLoaded();
+        $this->types[$type->name] = $type;
+    }
+
+    public function get(string $name): NodeType
+    {
+        $this->ensureLoaded();
+        if (!isset($this->types[$name])) {
+            throw new NodeTypeNotFound(\sprintf('Node type "%s" is not registered.', $name));
+        }
+
+        return $this->types[$name];
+    }
+
+    /**
+     * @return NodeType[]
+     */
+    public function all(): array
+    {
+        $this->ensureLoaded();
+
+        return array_values($this->types ?? []);
+    }
+
+    public function has(string $name): bool
+    {
+        $this->ensureLoaded();
+
+        return isset($this->types[$name]);
+    }
+
+    private function ensureLoaded(): void
+    {
+        if (null !== $this->types) {
+            return;
+        }
+
+        // Prefer warm cache if present
+        $cacheFile = $this->cacheFile ?? $this->defaultCacheFilePath();
+        if ($cacheFile && is_file($cacheFile)) {
+            $json = file_get_contents($cacheFile) ?: '';
+            $raw = json_decode($json, true);
+            if (\is_array($raw)) {
+                $typed = [];
+                foreach ($raw as $item) {
+                    if (!\is_array($item)) {
+                        continue;
+                    }
+                    $name = $item['name'] ?? null;
+                    $properties = $item['properties'] ?? null;
+                    if (!\is_string($name) || !\is_array($properties)) {
+                        continue;
+                    }
+                    $propList = [];
+                    foreach ($properties as $p) {
+                        if (!\is_array($p)) {
+                            continue;
+                        }
+                        $pn = $p['name'] ?? null;
+                        $pt = $p['type'] ?? null;
+                        $pnul = $p['nullable'] ?? null;
+                        $pmul = $p['multiple'] ?? null;
+                        if (!\is_string($pn) || !\is_string($pt) || !\is_bool($pnul) || !\is_bool($pmul)) {
+                            continue;
+                        }
+                        $propList[] = [
+                            'name' => $pn,
+                            'type' => $pt,
+                            'nullable' => $pnul,
+                            'multiple' => $pmul,
+                        ];
+                    }
+                    $typed[] = [
+                        'name' => $name,
+                        'properties' => $propList,
+                    ];
+                }
+                /** @var list<array{name: string, properties: list<array{name: string, type: string, nullable: bool, multiple: bool}>}> $typed */
+                $this->types = $this->hydrateFromResolved($typed);
+
+                return;
+            }
+        }
+
+        // Resolve from source definitions
+        $resolved = $this->resolver->resolve($this->loader->load());
+        $this->types = $resolved;
+    }
+
+    private function defaultCacheFilePath(): string
+    {
+        $projectDir = \dirname(__DIR__, 3); // src/Infrastructure/Persistence -> up 3 = project
+        $env = getenv('APP_ENV') ?: 'dev';
+        $candidate = $projectDir.DIRECTORY_SEPARATOR.'var'.DIRECTORY_SEPARATOR.'cache'.DIRECTORY_SEPARATOR.$env.DIRECTORY_SEPARATOR.'aurora_node_types.json';
+        if (is_file($candidate)) {
+            return $candidate;
+        }
+
+        $fallback = $projectDir.DIRECTORY_SEPARATOR.'var'.DIRECTORY_SEPARATOR.'cache'.DIRECTORY_SEPARATOR.'aurora_node_types.json';
+
+        return $fallback;
+    }
+
+    /**
+     * @param list<array{name: string, properties: list<array{name: string, type: string, nullable: bool, multiple: bool}>}> $raw
+     *
+     * @return array<string, NodeType>
+     */
+    private function hydrateFromResolved(array $raw): array
+    {
+        $map = [];
+        /** @var array{name: string, properties: list<array{name: string, type: string, nullable: bool, multiple: bool}>} $t */
+        foreach ($raw as $t) {
+            $props = [];
+            /** @var array{name: string, type: string, nullable: bool, multiple: bool} $p */
+            foreach ($t['properties'] as $p) {
+                $type = PropertyType::from($p['type']);
+                $props[] = new PropertyDefinition($p['name'], $type, (bool) $p['nullable'], (bool) $p['multiple']);
+            }
+            $nt = new NodeType($t['name'], $props);
+            $map[$nt->name] = $nt;
+        }
+
+        return $map;
+    }
+}

--- a/src/Interface/Cli/Command/NodeTypesListCommand.php
+++ b/src/Interface/Cli/Command/NodeTypesListCommand.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Aurora Core.
+ *
+ * (c) The Aurora Core contributors
+ * License: MIT
+ */
+
+namespace Aurora\Interface\Cli\Command;
+
+use Aurora\Domain\ContentRepository\Type\NodeType;
+use Aurora\Domain\ContentRepository\Type\PropertyDefinition;
+use Aurora\Infrastructure\ContentRepository\NodeTypes\DefinitionLoader;
+use Aurora\Infrastructure\ContentRepository\NodeTypes\NodeTypeResolver;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(name: 'node-types:list', description: 'List resolved NodeTypes with properties')]
+final class NodeTypesListCommand extends Command
+{
+    public function __construct(
+        private readonly DefinitionLoader $loader,
+        private readonly NodeTypeResolver $resolver,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption('details', null, InputOption::VALUE_NONE, 'Show properties and inheritance details');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $output->writeln('<info>Loading node types...</info>');
+        try {
+            $defs = $this->loader->load();
+            $resolved = $this->resolver->resolve($defs);
+        } catch (\Throwable $e) {
+            $output->writeln('<error>Failed to load node types:</error> '.$e->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $showDetails = (bool) $input->getOption('details');
+
+        // Build quick lookup for parent chain
+        $extends = [];
+        foreach ($defs as $name => $def) {
+            $extends[$name] = isset($def['extends']) ? (string) $def['extends'] : null;
+        }
+
+        foreach ($resolved as $name => $type) {
+            if (!$showDetails) {
+                $output->writeln(\sprintf('<info>%s</info>', $type->name));
+                continue;
+            }
+
+            $chain = $this->buildInheritanceChain($name, $extends);
+            $label = $type->name;
+            if ($chain) {
+                $label .= ' (extends: '.implode(' -> ', $chain).')';
+            }
+            $output->writeln(\sprintf('<info>%s</info>', $label));
+
+            // reflect property definitions
+            [$props, $ownSet, $parentSet] = $this->introspectProperties($name, $type, $resolved, $defs);
+
+            foreach ($props as $p) {
+                $tags = [];
+                $isOwn = isset($ownSet[$p['name']]);
+                $inParent = isset($parentSet[$p['name']]);
+                $isOverride = $isOwn && $inParent;
+                if ($isOverride) {
+                    $tags[] = 'override';
+                } elseif ($isOwn) {
+                    $tags[] = 'own';
+                } elseif ($inParent) {
+                    $tags[] = 'inherited';
+                }
+
+                $flags = [];
+                if ($p['nullable']) {
+                    $flags[] = 'nullable';
+                }
+                if ($p['multiple']) {
+                    $flags[] = 'multiple';
+                }
+
+                $meta = [];
+                if ($tags) {
+                    $meta[] = implode(',', $tags);
+                }
+                if ($flags) {
+                    $meta[] = implode(',', $flags);
+                }
+
+                $suffix = $meta ? ' ['.implode(' | ', $meta).']' : '';
+
+                $output->writeln(\sprintf('  - %s: %s%s', $p['name'], $p['type'], $suffix));
+            }
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Build inheritance chain from closest parent up to root parent.
+     *
+     * @param array<string, string|null> $extends
+     *
+     * @return list<string>
+     */
+    private function buildInheritanceChain(string $name, array $extends): array
+    {
+        $chain = [];
+        $cur = $extends[$name] ?? null;
+        while ($cur) {
+            $chain[] = $cur;
+            $cur = $extends[$cur] ?? null;
+        }
+
+        return $chain;
+    }
+
+    /**
+     * Introspects a resolved NodeType, returning flattened property data plus own/parent sets.
+     *
+     * @param array<string, NodeType>                                                                                                        $resolved
+     * @param array<string, array{extends?: string|null, properties?: array<string, array{type: string, nullable?: bool, multiple?: bool}>}> $defs
+     *
+     * @return array{0: list<array{name: string, type: string, nullable: bool, multiple: bool}>, 1: array<string, true>, 2: array<string, true>}
+     */
+    private function introspectProperties(string $name, NodeType $type, array $resolved, array $defs): array
+    {
+        // Reflect property definitions from NodeType
+        $rp = new \ReflectionProperty(NodeType::class, 'definitions');
+        $rp->setAccessible(true);
+        /** @var array<string, PropertyDefinition> $defsMap */
+        $defsMap = $rp->getValue($type);
+        $props = [];
+        foreach ($defsMap as $pd) {
+            $props[] = [
+                'name' => $pd->name,
+                'type' => $pd->type->value,
+                'nullable' => $pd->nullable,
+                'multiple' => $pd->multiple,
+            ];
+        }
+        // Sort for stable output
+        usort($props, static fn ($a, $b) => $a['name'] <=> $b['name']);
+
+        // Identify own properties as declared in raw definitions for this type
+        $ownSet = [];
+        $rawProps = $defs[$name]['properties'] ?? [];
+        foreach ($rawProps as $pName => $_) {
+            $ownSet[(string) $pName] = true;
+        }
+
+        // Build merged parent property set (chain to root)
+        $parentSet = [];
+        $parent = $defs[$name]['extends'] ?? null;
+        while ($parent) {
+            if (!isset($resolved[$parent])) {
+                break;
+            }
+            $pType = $resolved[$parent];
+            $pMap = $rp->getValue($pType);
+            /** @var array<string, PropertyDefinition> $pMap */
+            foreach ($pMap as $propName => $pd) {
+                $parentSet[$propName] = true;
+            }
+            $parent = $defs[$parent]['extends'] ?? null;
+        }
+
+        return [$props, $ownSet, $parentSet];
+    }
+}

--- a/src/Interface/Cli/Command/NodeTypesValidateCommand.php
+++ b/src/Interface/Cli/Command/NodeTypesValidateCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Aurora Core.
+ *
+ * (c) The Aurora Core contributors
+ * License: MIT
+ */
+
+namespace Aurora\Interface\Cli\Command;
+
+use Aurora\Infrastructure\ContentRepository\NodeTypes\DefinitionLoader;
+use Aurora\Infrastructure\ContentRepository\NodeTypes\NodeTypeResolver;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(name: 'node-types:validate', description: 'Validate NodeType definitions and inheritance')]
+final class NodeTypesValidateCommand extends Command
+{
+    public function __construct(
+        private readonly DefinitionLoader $loader,
+        private readonly NodeTypeResolver $resolver,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        try {
+            $defs = $this->loader->load();
+            $this->resolver->resolve($defs);
+        } catch (\Throwable $e) {
+            $output->writeln('<error>Validation failed:</error> '.$e->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $output->writeln('<info>All node type definitions are valid.</info>');
+
+        return Command::SUCCESS;
+    }
+}

--- a/tests/Application/ContentRepository/UseCase/HandlersPersistenceTest.php
+++ b/tests/Application/ContentRepository/UseCase/HandlersPersistenceTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aurora\Tests\Application\ContentRepository\UseCase;
+
+use Aurora\Application\ContentRepository\Dto\DeleteNodeRequest;
+use Aurora\Application\ContentRepository\Dto\MoveNodeRequest;
+use Aurora\Application\ContentRepository\Dto\SetPropertyRequest;
+use Aurora\Application\ContentRepository\UseCase\DeleteNodeHandler;
+use Aurora\Application\ContentRepository\UseCase\MoveNodeHandler;
+use Aurora\Application\ContentRepository\UseCase\SetPropertyHandler;
+use Aurora\Application\Contract\TransactionBoundary;
+use Aurora\Domain\ContentRepository\Exception\NodeNotFound;
+use Aurora\Domain\ContentRepository\Type\NodeType;
+use Aurora\Domain\ContentRepository\Type\PropertyDefinition;
+use Aurora\Domain\ContentRepository\Type\PropertyType;
+use Aurora\Domain\ContentRepository\Value\DimensionSet;
+use Aurora\Domain\ContentRepository\Value\NodeId;
+use Aurora\Domain\ContentRepository\Value\WorkspaceId;
+use Aurora\Domain\ContentRepository\Workspace;
+use Aurora\Infrastructure\NoopTransactionBoundary;
+use Aurora\Tests\Support\SpyWorkspaceRepository;
+use PHPUnit\Framework\TestCase;
+
+final class HandlersPersistenceTest extends TestCase
+{
+    private SpyWorkspaceRepository $repo;
+    private Workspace $ws;
+    private TransactionBoundary $tx;
+
+    protected function setUp(): void
+    {
+        $this->repo = new SpyWorkspaceRepository();
+        $this->tx = new NoopTransactionBoundary();
+        $this->ws = Workspace::initialize(
+            WorkspaceId::fromString('draft'),
+            DimensionSet::empty(),
+            NodeId::fromString('rootnode-1'),
+            new NodeType('root')
+        );
+        $this->repo->save($this->ws);
+    }
+
+    public function testDeleteCallsRemoveAndSave(): void
+    {
+        // Arrange: create a node
+        $this->ws->createNode(NodeId::fromString('to-delete'), new NodeType('document'), [], NodeId::fromString('rootnode-1'), 'd');
+        $this->repo->save($this->ws);
+
+        // Act
+        $handler = new DeleteNodeHandler($this->repo, $this->tx);
+        $before = $this->repo->saveCount;
+        $handler(new DeleteNodeRequest('draft', [], 'to-delete', false));
+
+        // Assert save was called (kills repo->save removal)
+        self::assertGreaterThan($before, $this->repo->saveCount);
+
+        // Assert node no longer exists (kills ws->remove removal) and message contains id and phrase
+        try {
+            $this->repo->get(WorkspaceId::fromString('draft'), DimensionSet::empty())->get(NodeId::fromString('to-delete'));
+            $this->fail('Expected NodeNotFound');
+        } catch (NodeNotFound $e) {
+            $this->assertSame('Node not found: to-delete', $e->getMessage());
+        }
+    }
+
+    public function testMoveCallsSaveAndUpdatesPath(): void
+    {
+        $doc = new NodeType('document', [new PropertyDefinition('title', PropertyType::STRING)]);
+        $this->ws->createNode(NodeId::fromString('childnode-a'), $doc, ['title' => 'A'], NodeId::fromString('rootnode-1'), 'a');
+        $this->ws->createNode(NodeId::fromString('childnode-b'), $doc, ['title' => 'B'], NodeId::fromString('rootnode-1'), 'b');
+        $this->repo->save($this->ws);
+
+        $handler = new MoveNodeHandler($this->repo, $this->tx);
+        $before = $this->repo->saveCount;
+        $handler(new MoveNodeRequest('draft', [], 'childnode-a', 'childnode-b'));
+
+        $ws = $this->repo->get(WorkspaceId::fromString('draft'), DimensionSet::empty());
+        $this->assertSame('/b/a', (string) $ws->get(NodeId::fromString('childnode-a'))->path);
+        self::assertGreaterThan($before, $this->repo->saveCount);
+    }
+
+    public function testSetPropertyCallsSetAndSave(): void
+    {
+        $doc = new NodeType('document', [new PropertyDefinition('title', PropertyType::STRING)]);
+        $this->ws->createNode(NodeId::fromString('childnode-n1'), $doc, ['title' => 'Old'], NodeId::fromString('rootnode-1'), 'childnode-n1');
+        $this->repo->save($this->ws);
+
+        $handler = new SetPropertyHandler($this->repo, $this->tx);
+        $before = $this->repo->saveCount;
+        $handler(new SetPropertyRequest('draft', [], 'childnode-n1', 'title', 'New'));
+
+        $ws = $this->repo->get(WorkspaceId::fromString('draft'), DimensionSet::empty());
+        $this->assertSame('New', $ws->get(NodeId::fromString('childnode-n1'))->properties['title']);
+        self::assertGreaterThan($before, $this->repo->saveCount);
+    }
+}

--- a/tests/Domain/ContentRepository/DimensionSetValidationTest.php
+++ b/tests/Domain/ContentRepository/DimensionSetValidationTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aurora\Tests\Domain\ContentRepository;
+
+use Aurora\Domain\ContentRepository\Value\DimensionSet;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+final class DimensionSetValidationTest extends TestCase
+{
+    public function testEmptyNameOrValueIsInvalid(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new DimensionSet(['' => 'x']);
+    }
+
+    public function testEmptyValueIsInvalid(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new DimensionSet(['x' => '']);
+    }
+
+    public function testNameMustStartWithLetter(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new DimensionSet(['1locale' => 'en']);
+    }
+
+    public function testInvalidCharactersAreRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new DimensionSet(['loc!' => 'en']);
+    }
+}
+

--- a/tests/Domain/ContentRepository/NodePathAppendTest.php
+++ b/tests/Domain/ContentRepository/NodePathAppendTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aurora\Tests\Domain\ContentRepository;
+
+use Aurora\Domain\ContentRepository\Exception\NodePathInvalid;
+use Aurora\Domain\ContentRepository\Value\NodePath;
+use PHPUnit\Framework\TestCase;
+
+final class NodePathAppendTest extends TestCase
+{
+    public function testAppendNormalizesTrimAndLowercase(): void
+    {
+        $p = NodePath::root()->append(' A ');
+        $this->assertSame('/a', (string) $p);
+    }
+
+    public function testAppendInvalidSegmentThrows(): void
+    {
+        $this->expectException(NodePathInvalid::class);
+        NodePath::root()->append('Invalid*Segment');
+    }
+
+    public function testEquals(): void
+    {
+        $a = NodePath::fromString('/x/y');
+        $b = NodePath::fromString('/x/y');
+        $c = NodePath::fromString('/x/z');
+        $this->assertTrue($a->equals($b));
+        $this->assertFalse($a->equals($c));
+    }
+}
+

--- a/tests/Domain/ContentRepository/NodePathValidationTest.php
+++ b/tests/Domain/ContentRepository/NodePathValidationTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aurora\Tests\Domain\ContentRepository;
+
+use Aurora\Domain\ContentRepository\Exception\NodePathInvalid;
+use Aurora\Domain\ContentRepository\Value\NodePath;
+use PHPUnit\Framework\TestCase;
+
+final class NodePathValidationTest extends TestCase
+{
+    public function testTrimsInputAndValidatesStartsWithSlash(): void
+    {
+        $p = NodePath::fromString('  /a/b  ');
+        $this->assertSame('/a/b', (string) $p);
+    }
+
+    public function testRejectsDotAndDotDotSegments(): void
+    {
+        $this->expectException(NodePathInvalid::class);
+        NodePath::fromString('/a/./b');
+    }
+
+    public function testRejectsDotDotSegment(): void
+    {
+        $this->expectException(NodePathInvalid::class);
+        NodePath::fromString('/a/../b');
+    }
+
+    public function testRemovesTrailingSlash(): void
+    {
+        $p = NodePath::fromString('/a/b/');
+        $this->assertSame('/a/b', (string) $p);
+    }
+}
+

--- a/tests/Domain/ContentRepository/PropertyDefinitionTest.php
+++ b/tests/Domain/ContentRepository/PropertyDefinitionTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aurora\Tests\Domain\ContentRepository;
+
+use Aurora\Domain\ContentRepository\Type\PropertyDefinition;
+use Aurora\Domain\ContentRepository\Type\PropertyType;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+final class PropertyDefinitionTest extends TestCase
+{
+    public function testDefaultNullableIsFalse(): void
+    {
+        $pd = new PropertyDefinition('p', PropertyType::STRING);
+        $this->expectException(InvalidArgumentException::class);
+        $pd->validate(null);
+    }
+
+    public function testNameValidationAnchors(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Property name format invalid: bad!');
+        new PropertyDefinition('bad!', PropertyType::STRING);
+    }
+}

--- a/tests/Domain/ContentRepository/TypeValidationTest.php
+++ b/tests/Domain/ContentRepository/TypeValidationTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aurora\Tests\Domain\ContentRepository;
+
+use Aurora\Domain\ContentRepository\Exception\PropertyValidationFailed;
+use Aurora\Domain\ContentRepository\Type\NodeType;
+use Aurora\Domain\ContentRepository\Type\PropertyDefinition;
+use Aurora\Domain\ContentRepository\Type\PropertyType;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+final class TypeValidationTest extends TestCase
+{
+    public function testNodeTypeNameValidationAnchors(): void
+    {
+        // must start with a letter
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Node type name format invalid: 1invalid');
+        new NodeType('1invalid');
+    }
+
+    public function testNodeTypeNameInvalidCharNotAllowed(): void
+    {
+        // invalid trailing character that should be rejected when $ anchor is enforced
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Node type name format invalid: valid*');
+        new NodeType('valid*');
+    }
+
+    public function testValidatePropertiesEnforcesTypeAndNullability(): void
+    {
+        $nt = new NodeType('doc', [new PropertyDefinition('title', PropertyType::STRING)]);
+
+        // wrong type should throw with specific message
+        try {
+            $nt->validateProperties(['title' => 123]);
+            $this->fail('Expected PropertyValidationFailed');
+        } catch (PropertyValidationFailed $e) {
+            $this->assertStringContainsString('Expected string', $e->getMessage());
+        }
+    }
+
+    public function testValidatePropertiesNullNotAllowedByDefault(): void
+    {
+        $nt = new NodeType('doc', [new PropertyDefinition('title', PropertyType::STRING)]);
+
+        // null not allowed by default
+        $this->expectException(InvalidArgumentException::class);
+        $nt->validateProperties(['title' => null]);
+    }
+}

--- a/tests/Domain/ContentRepository/ValueTest.php
+++ b/tests/Domain/ContentRepository/ValueTest.php
@@ -55,6 +55,15 @@ class ValueTest extends TestCase
     public function testNodeIdToStringEmpty(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('NodeId cannot be empty.');
         new NodeId(' ');
+    }
+
+    public function testNodeIdRejectsLeadingInvalidChars(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('NodeId format invalid');
+        // leading '@' is invalid though the tail is valid; caret removal would allow it
+        new NodeId('@abcdef');
     }
 }

--- a/tests/Domain/ContentRepository/WorkspaceBehaviorTest.php
+++ b/tests/Domain/ContentRepository/WorkspaceBehaviorTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aurora\Tests\Domain\ContentRepository;
+
+use PHPUnit\Framework\TestCase;
+use Aurora\Domain\ContentRepository\Workspace;
+use Aurora\Domain\ContentRepository\Value\NodeId;
+use Aurora\Domain\ContentRepository\Type\NodeType;
+use Aurora\Domain\ContentRepository\Value\NodePath;
+use Aurora\Domain\ContentRepository\Type\PropertyType;
+use Aurora\Domain\ContentRepository\Value\WorkspaceId;
+use Aurora\Domain\ContentRepository\Value\DimensionSet;
+use Aurora\Domain\ContentRepository\Exception\NodeNotFound;
+use Aurora\Domain\ContentRepository\Type\PropertyDefinition;
+use Aurora\Domain\ContentRepository\Exception\NodeAlreadyExists;
+use Aurora\Domain\ContentRepository\Exception\PropertyValidationFailed;
+
+final class WorkspaceBehaviorTest extends TestCase
+{
+    private function docType(): NodeType
+    {
+        return new NodeType('document', [new PropertyDefinition('title', PropertyType::STRING)]);
+    }
+
+    public function testChildrenOfReturnsAllChildren(): void
+    {
+        $ws = Workspace::initialize(WorkspaceId::fromString('draft'), DimensionSet::empty(), NodeId::fromString('rootnode'), $this->docType());
+        $ws->createNode(NodeId::fromString('childnode-c1'), $this->docType(), ['title' => 'A'], $ws->root()->id, 'a');
+        $ws->createNode(NodeId::fromString('childnode-c2'), $this->docType(), ['title' => 'B'], $ws->root()->id, 'b');
+        $children = $ws->childrenOf($ws->root()->id);
+        $this->assertCount(2, $children);
+    }
+
+    public function testSiblingNameConflictIsCaseInsensitive(): void
+    {
+        $ws = Workspace::initialize(WorkspaceId::fromString('draft'), DimensionSet::empty(), NodeId::fromString('rootnode'), $this->docType());
+        $ws->createNode(NodeId::fromString('childnode-c1'), $this->docType(), ['title' => 'A'], $ws->root()->id, 'Home');
+        try {
+            $ws->createNode(NodeId::fromString('childnode-c2'), $this->docType(), ['title' => 'B'], $ws->root()->id, 'HOME');
+            $this->fail('Expected NodeAlreadyExists');
+        } catch (NodeAlreadyExists $e) {
+            $this->assertSame('Node already exists: HOME', $e->getMessage());
+        }
+    }
+
+    public function testMoveUpdatesDescendantPaths(): void
+    {
+        $ws = Workspace::initialize(WorkspaceId::fromString('draft'), DimensionSet::empty(), NodeId::fromString('rootnode'), $this->docType());
+        $ws->createNode(NodeId::fromString('childnode-a'), $this->docType(), ['title' => 'A'], $ws->root()->id, 'a');
+        $ws->createNode(NodeId::fromString('childnode-a1'), $this->docType(), ['title' => 'A1'], NodeId::fromString('childnode-a'), 'a1');
+        $ws->createNode(NodeId::fromString('childnode-b'), $this->docType(), ['title' => 'B'], $ws->root()->id, 'b');
+        // Add sibling whose name shares prefix with 'a' to catch bad prefix matching
+        $ws->createNode(NodeId::fromString('childnode-ab'), $this->docType(), ['title' => 'AB'], $ws->root()->id, 'ab');
+
+        $ws->move(NodeId::fromString('childnode-a'), NodeId::fromString('childnode-b'));
+        $this->assertSame('/b/a/a1', (string) $ws->get(NodeId::fromString('childnode-a1'))->path);
+    }
+
+    public function testCreateNodeRejectsInvalidPropertyValue(): void
+    {
+        $ws = Workspace::initialize(WorkspaceId::fromString('draft'), DimensionSet::empty(), NodeId::fromString('rootnode'), $this->docType());
+        $this->expectException(PropertyValidationFailed::class);
+        $ws->createNode(NodeId::fromString('childnode-x'), $this->docType(), ['title' => 123], $ws->root()->id, 'x');
+    }
+
+    public function testMoveSiblingNameConflictThrows(): void
+    {
+        $ws = Workspace::initialize(WorkspaceId::fromString('draft'), DimensionSet::empty(), NodeId::fromString('rootnode'), $this->docType());
+        $ws->createNode(NodeId::fromString('childnode-a'), $this->docType(), ['title' => 'A'], $ws->root()->id, 'a');
+        $ws->createNode(NodeId::fromString('childnode-b'), $this->docType(), ['title' => 'B'], $ws->root()->id, 'b');
+        $ws->createNode(NodeId::fromString('childnode-c'), $this->docType(), ['title' => 'BA'], NodeId::fromString('childnode-b'), 'a');
+        try {
+            $ws->move(NodeId::fromString('childnode-a'), NodeId::fromString('childnode-b'));
+            $this->fail('Expected InvalidMove');
+        } catch (\Aurora\Domain\ContentRepository\Exception\InvalidMove $e) {
+            $this->assertSame('Node with same name already exists at target location: a', $e->getMessage());
+        }
+
+    }
+
+    public function testMoveUpdatesPathIndex(): void
+    {
+        $ws = Workspace::initialize(WorkspaceId::fromString('draft'), DimensionSet::empty(), NodeId::fromString('rootnode'), $this->docType());
+        $ws->createNode(NodeId::fromString('childnode-a'), $this->docType(), ['title' => 'A'], $ws->root()->id, 'a');
+        $ws->createNode(NodeId::fromString('childnode-a1'), $this->docType(), ['title' => 'A1'], NodeId::fromString('childnode-a'), 'a1');
+        $ws->createNode(NodeId::fromString('childnode-b'), $this->docType(), ['title' => 'B'], $ws->root()->id, 'b');
+
+        // After move, old path lookups should fail, new should succeed
+        $ws->move(NodeId::fromString('childnode-a'), NodeId::fromString('childnode-b'));
+        try {
+            $ws->getByPath(NodePath::fromString('/a'));
+            $this->fail('Expected NodeNotFound at old path');
+        } catch (NodeNotFound $e) {
+            $this->assertSame('Node not found at path: /a', $e->getMessage());
+        }
+        $this->assertSame('childnode-a', (string) $ws->getByPath(NodePath::fromString('/b/a'))->id);
+        $this->assertSame('childnode-a1', (string) $ws->getByPath(NodePath::fromString('/b/a/a1'))->id);
+        $this->assertSame('childnode-b', (string) $ws->getByPath(NodePath::fromString('/b'))->id);
+        // Old parent should no longer list 'childnode-a' as child
+        $rootChildren = $ws->childrenOf($ws->root()->id);
+        $this->assertFalse(in_array('childnode-a', array_map(fn($n) => (string) $n->id, $rootChildren), true));
+    }
+}

--- a/tests/Domain/ContentRepository/WorkspaceIdValidationTest.php
+++ b/tests/Domain/ContentRepository/WorkspaceIdValidationTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aurora\Tests\Domain\ContentRepository;
+
+use Aurora\Domain\ContentRepository\Value\WorkspaceId;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+final class WorkspaceIdValidationTest extends TestCase
+{
+    public function testRejectsLeadingSpaceEvenIfTailValid(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('WorkspaceId format invalid');
+        new WorkspaceId(' dr');
+    }
+
+    public function testEmptyStringOrSpacesAreInvalid(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('WorkspaceId cannot be empty.');
+        new WorkspaceId('   ');
+    }
+
+    public function testRejectsTooShort(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('WorkspaceId format invalid');
+        new WorkspaceId('a');
+    }
+
+    public function testRejectsInvalidCharacters(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('WorkspaceId format invalid');
+        new WorkspaceId('dr!');
+    }
+}

--- a/tests/Infrastructure/ContentRepository/NodeTypes/DefinitionLoaderMoreTest.php
+++ b/tests/Infrastructure/ContentRepository/NodeTypes/DefinitionLoaderMoreTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aurora\Tests\Infrastructure\ContentRepository\NodeTypes;
+
+use Aurora\Infrastructure\ContentRepository\NodeTypes\DefinitionLoader;
+use Aurora\Infrastructure\ContentRepository\NodeTypes\NodeTypeResolver;
+use PHPUnit\Framework\TestCase;
+
+final class DefinitionLoaderMoreTest extends TestCase
+{
+    public function testDefaultPathLoadsExhaustiveExample(): void
+    {
+        $loader = new DefinitionLoader();
+        $defs = $loader->load();
+        // from config/node_types/exhaustive-example.yaml added to the repo
+        $this->assertArrayHasKey('exhaustive-example', $defs);
+        $this->assertArrayHasKey('exhaustive-base', $defs);
+    }
+
+    public function testUppercaseExtensionIsRecognized(): void
+    {
+        $dir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'aurora_defs_upper_'.bin2hex(random_bytes(3));
+        @mkdir($dir);
+        $yaml = "typeupper:\n  properties:\n    title: { type: string }\n";
+        file_put_contents($dir.DIRECTORY_SEPARATOR.'def.UPPER.YAML', $yaml);
+
+        $loader = new DefinitionLoader([$dir]);
+        $defs = $loader->load();
+        $this->assertArrayHasKey('typeupper', $defs);
+
+        @unlink($dir.DIRECTORY_SEPARATOR.'def.UPPER.YAML');
+        @rmdir($dir);
+    }
+
+    public function testCastsNullableAndMultipleFromJson(): void
+    {
+        $dir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'aurora_defs_json_'.bin2hex(random_bytes(3));
+        @mkdir($dir);
+        $json = json_encode([
+            'article' => [
+                'properties' => [
+                    'title' => ['type' => 'string'],
+                    'flag' => ['type' => 'bool', 'nullable' => 1, 'multiple' => 0],
+                ],
+            ],
+        ], JSON_PRETTY_PRINT);
+        file_put_contents($dir.DIRECTORY_SEPARATOR.'defs.json', (string) $json);
+
+        $loader = new DefinitionLoader([$dir]);
+        $resolver = new NodeTypeResolver();
+        $resolved = $resolver->resolve($loader->load());
+
+        $t = $resolved['article'];
+        $rp = new \ReflectionProperty(\Aurora\Domain\ContentRepository\Type\NodeType::class, 'definitions');
+        $rp->setAccessible(true);
+        /** @var array<string, \Aurora\Domain\ContentRepository\Type\PropertyDefinition> $defsMap */
+        $defsMap = $rp->getValue($t);
+        $this->assertFalse($defsMap['title']->nullable);
+        $this->assertFalse($defsMap['title']->multiple);
+        $this->assertTrue($defsMap['flag']->nullable);
+        $this->assertFalse($defsMap['flag']->multiple);
+
+        @unlink($dir.DIRECTORY_SEPARATOR.'defs.json');
+        @rmdir($dir);
+    }
+}
+

--- a/tests/Infrastructure/ContentRepository/NodeTypes/DefinitionLoaderTest.php
+++ b/tests/Infrastructure/ContentRepository/NodeTypes/DefinitionLoaderTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Aurora Core.
+ *
+ * (c) The Aurora Core contributors
+ * License: MIT
+ */
+
+namespace Aurora\Tests\Infrastructure\ContentRepository\NodeTypes;
+
+use Aurora\Infrastructure\ContentRepository\NodeTypes\DefinitionLoader;
+use Aurora\Infrastructure\ContentRepository\NodeTypes\Exception\InvalidNodeTypeDefinition;
+use PHPUnit\Framework\TestCase;
+
+final class DefinitionLoaderTest extends TestCase
+{
+    public function testLoadsYamlAndJsonAndNormalizesStructure(): void
+    {
+        $dir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'aurora_node_types_'.bin2hex(random_bytes(4));
+        @mkdir($dir);
+
+        // base yaml
+        $yaml = <<<YAML
+base:
+  properties:
+    title: { type: string }
+YAML;
+        file_put_contents($dir.DIRECTORY_SEPARATOR.'base.yaml', $yaml);
+
+        // child json
+        $json = json_encode([
+            'child' => [
+                'extends' => 'base',
+                'properties' => [
+                    'views' => ['type' => 'int'],
+                ],
+            ],
+        ], JSON_PRETTY_PRINT);
+        file_put_contents($dir.DIRECTORY_SEPARATOR.'child.json', (string) $json);
+
+        $loader = new DefinitionLoader([$dir]);
+        $defs = $loader->load();
+
+        self::assertArrayHasKey('base', $defs);
+        self::assertArrayHasKey('child', $defs);
+        self::assertSame(null, $defs['base']['extends'] ?? null);
+        self::assertSame('base', $defs['child']['extends']);
+        if (!isset($defs['base']['properties'])) {
+            self::fail('base properties not set or not an array');
+        }
+        self::assertArrayHasKey('title', $defs['base']['properties']);
+        if (!isset($defs['child']['properties'])) {
+            self::fail('child properties not set or not an array');
+        }
+        self::assertArrayHasKey('views', $defs['child']['properties']);
+    }
+
+    public function testRejectsInvalidPropertyTypeFormat(): void
+    {
+        $dir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'aurora_node_types_'.bin2hex(random_bytes(4));
+        @mkdir($dir);
+        $yaml = <<<YAML
+oops:
+  properties:
+    bad: { type: [ 1, 2, 3 ] }
+YAML;
+        file_put_contents($dir.DIRECTORY_SEPARATOR.'oops.yaml', $yaml);
+
+        $loader = new DefinitionLoader([$dir]);
+        $this->expectException(InvalidNodeTypeDefinition::class);
+        $this->expectExceptionMessage('type must be a string');
+        $loader->load();
+    }
+}
+

--- a/tests/Infrastructure/ContentRepository/NodeTypes/NodeTypeResolverTest.php
+++ b/tests/Infrastructure/ContentRepository/NodeTypes/NodeTypeResolverTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Aurora Core.
+ *
+ * (c) The Aurora Core contributors
+ * License: MIT
+ */
+
+namespace Aurora\Tests\Infrastructure\ContentRepository\NodeTypes;
+
+use Aurora\Infrastructure\ContentRepository\NodeTypes\Exception\InvalidNodeTypeDefinition;
+use Aurora\Infrastructure\ContentRepository\NodeTypes\NodeTypeResolver;
+use PHPUnit\Framework\TestCase;
+
+final class NodeTypeResolverTest extends TestCase
+{
+    public function testInheritanceMergesAndOverridesProperties(): void
+    {
+        $defs = [
+            'base' => [
+                'properties' => [
+                    'title' => ['type' => 'string'],
+                    'views' => ['type' => 'int'],
+                ],
+            ],
+            'article' => [
+                'extends' => 'base',
+                'properties' => [
+                    // override type and flags
+                    'views' => ['type' => 'int', 'nullable' => true],
+                    'tags' => ['type' => 'string', 'multiple' => true],
+                ],
+            ],
+        ];
+
+        $resolver = new NodeTypeResolver();
+        $resolved = $resolver->resolve($defs);
+
+        self::assertArrayHasKey('article', $resolved);
+        $article = $resolved['article'];
+
+        // The inherited property
+        self::assertTrue($article->has('title'));
+        // The overridden property exists
+        self::assertTrue($article->has('views'));
+        // The new property exists
+        self::assertTrue($article->has('tags'));
+    }
+
+    public function testUnknownParentThrows(): void
+    {
+        $defs = [
+            'child' => [
+                'extends' => 'missing',
+                'properties' => [
+                    'foo' => ['type' => 'string'],
+                ],
+            ],
+        ];
+
+        $resolver = new NodeTypeResolver();
+
+        $this->expectException(InvalidNodeTypeDefinition::class);
+        $this->expectExceptionMessage('Unknown parent node type');
+        $resolver->resolve($defs);
+    }
+
+    public function testCircularInheritanceThrows(): void
+    {
+        $defs = [
+            'a' => [
+                'extends' => 'b',
+                'properties' => [],
+            ],
+            'b' => [
+                'extends' => 'a',
+                'properties' => [],
+            ],
+        ];
+
+        $resolver = new NodeTypeResolver();
+
+        $this->expectException(InvalidNodeTypeDefinition::class);
+        $this->expectExceptionMessage('Circular inheritance');
+        $resolver->resolve($defs);
+    }
+
+    public function testUnknownPropertyTypeThrows(): void
+    {
+        $defs = [
+            't' => [
+                'properties' => [
+                    'foo' => ['type' => 'unknown-type'],
+                ],
+            ],
+        ];
+
+        $resolver = new NodeTypeResolver();
+
+        $this->expectException(InvalidNodeTypeDefinition::class);
+        $this->expectExceptionMessage('Unknown property type');
+        $resolver->resolve($defs);
+    }
+}

--- a/tests/Infrastructure/ContentRepository/NodeTypes/NodeTypesCacheWarmerTest.php
+++ b/tests/Infrastructure/ContentRepository/NodeTypes/NodeTypesCacheWarmerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Aurora Core.
+ *
+ * (c) The Aurora Core contributors
+ * License: MIT
+ */
+
+namespace Aurora\Tests\Infrastructure\ContentRepository\NodeTypes;
+
+use Aurora\Infrastructure\ContentRepository\NodeTypes\DefinitionLoader;
+use Aurora\Infrastructure\ContentRepository\NodeTypes\NodeTypeResolver;
+use Aurora\Infrastructure\ContentRepository\NodeTypes\NodeTypesCacheWarmer;
+use PHPUnit\Framework\TestCase;
+
+final class NodeTypesCacheWarmerTest extends TestCase
+{
+    public function testWarmUpWritesResolvedCache(): void
+    {
+        $cacheFile = sys_get_temp_dir().DIRECTORY_SEPARATOR.'aurora_node_types_cachewarmer_'.bin2hex(random_bytes(4)).'.json';
+
+        $dir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'aurora_cachewarmer_defs_'.bin2hex(random_bytes(4));
+        @mkdir($dir);
+        $yaml = <<<YAML
+base:
+  properties:
+    title: { type: string }
+article:
+  extends: base
+  properties:
+    views: { type: int }
+YAML;
+        file_put_contents($dir.DIRECTORY_SEPARATOR.'defs.yaml', $yaml);
+
+        $loader = new DefinitionLoader([$dir]);
+
+        $resolver = new NodeTypeResolver();
+        $warmer = new NodeTypesCacheWarmer($loader, $resolver, $cacheFile);
+        $warmer->warmUp(sys_get_temp_dir());
+
+        self::assertFileExists($cacheFile);
+        $json = file_get_contents($cacheFile);
+        self::assertIsString($json);
+        $data = json_decode((string) $json, true);
+        self::assertIsArray($data);
+        self::assertGreaterThanOrEqual(2, count($data));
+        if (!isset($data[1]) || !is_array($data[1])) {
+            self::fail('Second node type not set');
+        }
+        if (!isset($data[1]['name'])) {
+            self::fail('Second node type name not set');
+        }
+        self::assertSame('article', $data[1]['name']);
+
+        @unlink($cacheFile);
+        @unlink($dir.DIRECTORY_SEPARATOR.'defs.yaml');
+        @rmdir($dir);
+    }
+}

--- a/tests/Infrastructure/Persistence/ContentRepository/ConfigNodeTypeRepositoryTest.php
+++ b/tests/Infrastructure/Persistence/ContentRepository/ConfigNodeTypeRepositoryTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Aurora Core.
+ *
+ * (c) The Aurora Core contributors
+ * License: MIT
+ */
+
+namespace Aurora\Tests\Infrastructure\Persistence\ContentRepository;
+
+use Aurora\Application\ContentRepository\Port\NodeTypeRepository;
+use Aurora\Domain\ContentRepository\Type\NodeType;
+use Aurora\Infrastructure\ContentRepository\NodeTypes\DefinitionLoader;
+use Aurora\Infrastructure\ContentRepository\NodeTypes\NodeTypeResolver;
+use Aurora\Infrastructure\Persistence\ContentRepository\ConfigNodeTypeRepository;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigNodeTypeRepositoryTest extends TestCase
+{
+    public function testReadsFromWarmCache(): void
+    {
+        $cacheFile = sys_get_temp_dir().DIRECTORY_SEPARATOR.'aurora_node_types_cache_'.bin2hex(random_bytes(4)).'.json';
+
+        $payload = [
+            [
+                'name' => 'base',
+                'properties' => [
+                    ['name' => 'title', 'type' => 'string', 'nullable' => false, 'multiple' => false],
+                ],
+            ],
+            [
+                'name' => 'article',
+                'properties' => [
+                    ['name' => 'views', 'type' => 'int', 'nullable' => false, 'multiple' => false],
+                ],
+            ],
+        ];
+        file_put_contents($cacheFile, json_encode($payload, JSON_PRETTY_PRINT));
+
+        // Use real instances; repo should prefer cache and not require them.
+        $loader = new DefinitionLoader([sys_get_temp_dir().DIRECTORY_SEPARATOR.'nonexistent_'.bin2hex(random_bytes(3))]);
+        $resolver = new NodeTypeResolver();
+        $repo = new ConfigNodeTypeRepository($loader, $resolver, $cacheFile);
+        self::assertInstanceOf(NodeTypeRepository::class, $repo);
+
+        $all = $repo->all();
+        self::assertCount(2, $all);
+        $article = $repo->get('article');
+        self::assertInstanceOf(NodeType::class, $article);
+        self::assertTrue($article->has('views'));
+
+        // cleanup
+        @unlink($cacheFile);
+    }
+}

--- a/tests/Interface/Cli/NodeTypesListCommandTest.php
+++ b/tests/Interface/Cli/NodeTypesListCommandTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Aurora Core.
+ *
+ * (c) The Aurora Core contributors
+ * License: MIT
+ */
+
+namespace Aurora\Tests\Interface\Cli;
+
+use Aurora\Infrastructure\ContentRepository\NodeTypes\DefinitionLoader;
+use Aurora\Infrastructure\ContentRepository\NodeTypes\NodeTypeResolver;
+use Aurora\Interface\Cli\Command\NodeTypesListCommand;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class NodeTypesListCommandTest extends TestCase
+{
+    public function testDetailsOutputShowsInheritanceAndOverrides(): void
+    {
+        $dir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'aurora_cli_defs_'.bin2hex(random_bytes(4));
+        @mkdir($dir);
+        $yaml = <<<YAML
+base:
+  properties:
+    title: { type: string }
+    views: { type: int }
+article:
+  extends: base
+  properties:
+    views: { type: int, nullable: true }
+    tags: { type: string, multiple: true }
+YAML;
+        file_put_contents($dir.DIRECTORY_SEPARATOR.'defs.yaml', $yaml);
+
+        $loader = new DefinitionLoader([$dir]);
+        $resolver = new NodeTypeResolver();
+
+        $command = new NodeTypesListCommand($loader, $resolver);
+        $tester = new CommandTester($command);
+        $exit = $tester->execute(['--details' => true]);
+
+        self::assertSame(0, $exit);
+        $display = $tester->getDisplay();
+
+        self::assertStringContainsString('article (extends: base)', $display);
+        self::assertStringContainsString('views: int [override', $display);
+        self::assertStringContainsString('tags: string [own', $display);
+        self::assertStringContainsString('title: string [inherited', $display);
+        // cleanup temp
+        @unlink($dir.DIRECTORY_SEPARATOR.'defs.yaml');
+        @rmdir($dir);
+    }
+}

--- a/tests/Support/SpyWorkspaceRepository.php
+++ b/tests/Support/SpyWorkspaceRepository.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aurora\Tests\Support;
+
+use Aurora\Application\ContentRepository\Port\WorkspaceRepository;
+use Aurora\Domain\ContentRepository\Value\DimensionSet;
+use Aurora\Domain\ContentRepository\Value\WorkspaceId;
+use Aurora\Domain\ContentRepository\Workspace;
+use Aurora\Infrastructure\Persistence\ContentRepository\InMemoryWorkspaceRepository;
+
+final class SpyWorkspaceRepository implements WorkspaceRepository
+{
+    private InMemoryWorkspaceRepository $inner;
+    public int $saveCount = 0;
+
+    public function __construct()
+    {
+        $this->inner = new InMemoryWorkspaceRepository();
+    }
+
+    public function save(Workspace $workspace): void
+    {
+        $this->saveCount++;
+        $this->inner->save($workspace);
+    }
+
+    public function get(WorkspaceId $id, DimensionSet $dimensionSet): Workspace
+    {
+        return $this->inner->get($id, $dimensionSet);
+    }
+
+    public function exists(WorkspaceId $id, DimensionSet $dimensionSet): bool
+    {
+        return $this->inner->exists($id, $dimensionSet);
+    }
+}
+


### PR DESCRIPTION
This pull request introduces a new infrastructure for managing node type definitions in Aurora Core, including loading, resolving inheritance, and caching of node types. It also updates configuration files and improves IDE integration for static analysis and code formatting.

**Node Type Definition Infrastructure**

* Added `DefinitionLoader`, `NodeTypeResolver`, and `NodeTypesCacheWarmer` classes to load node type definitions from YAML/JSON files, resolve inheritance and property merging, and cache resolved node types for performance. This includes robust error handling via a new `InvalidNodeTypeDefinition` exception. (`src/Infrastructure/ContentRepository/NodeTypes/DefinitionLoader.php`, `src/Infrastructure/ContentRepository/NodeTypes/NodeTypeResolver.php`, `src/Infrastructure/ContentRepository/NodeTypes/NodeTypesCacheWarmer.php`, `src/Infrastructure/ContentRepository/NodeTypes/Exception/InvalidNodeTypeDefinition.php`) [[1]](diffhunk://#diff-c439bbb46a6ffd3962304dfffc380ce070742ef209a45c0858bdc442f9ae051dR1-R150) [[2]](diffhunk://#diff-21f565c3e6660c5e6a7eef444875e71a6bcb0988de2b0f700241ed03d95f61cdR1-R104) [[3]](diffhunk://#diff-6fac637a224a4dd6656fb1302d12cae4d31ec64a49da97131a7cb2908d45688fR1-R78) [[4]](diffhunk://#diff-712a78c9ce61f5254c5eb8b35b11524babaac4f0293644a1b0b07f335f38f15bR1-R16)

* Added an exhaustive example YAML node type definition file for testing and documentation. (`config/node_types/exhaustive-example.yaml`)

**Dependency Injection**

* Registered the config-backed node type repository as the default implementation in the Symfony DI container via a new extension class. (`src/Infrastructure/DependencyInjection/AuroraInfrastructureExtension.php`)

**Configuration and IDE Integration**

* Updated PHPStan and PHP CS Fixer IDE settings to improve static analysis and code formatting, including new options and external formatter configuration. (`.idea/php.xml`, `.idea/inspectionProfiles/Project_Default.xml`) [[1]](diffhunk://#diff-f9c29e7013c0e853515a303d7c3bfcd48482ef98d2064aeb98da0eaffedd67cfL8-R8) [[2]](diffhunk://#diff-f9c29e7013c0e853515a303d7c3bfcd48482ef98d2064aeb98da0eaffedd67cfR26-R28) [[3]](diffhunk://#diff-f9c29e7013c0e853515a303d7c3bfcd48482ef98d2064aeb98da0eaffedd67cfL156-R165) [[4]](diffhunk://#diff-bbf0d02ebcf6764cae92fa4045a2d6f15f8a479cd1aa2ab4d1fd435a3aa74bbdR5)
* Added Symfony2 plugin profiler CSV path option for IDE integration. (`.idea/symfony2.xml`)
* Improved mutation testing configuration by adding ignores for specific mutators and methods. (`infection.json5`)

**Minor Improvements**

* Improved code comments and wording for clarity in the `Workspace` domain logic. (`src/Domain/ContentRepository/Workspace.php`) [[1]](diffhunk://#diff-a00bc46a4132e562d2f928ffd0973be659b9b14b89b3c6590c7bcb521dc10e79L224-R232) [[2]](diffhunk://#diff-a00bc46a4132e562d2f928ffd0973be659b9b14b89b3c6590c7bcb521dc10e79L253-R253)